### PR TITLE
Require python >= 3.7

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,7 +20,6 @@ jobs:
     strategy:
       matrix:
         python-version:
-        - '3.6'
         - '3.7'
         - '3.8'
         - '3.9'

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@
 # Dockerfile for running tests only.
 
 
-FROM python:3.6-slim
+FROM python:3.7-slim
 
 RUN apt-get update && apt-get install -y protobuf-compiler libprotobuf-dev
 

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setuptools.setup(
         'proto_task_queue.task_pb2',
         'proto_task_queue.worker',
     ],
-    python_requires='>=3.6',
+    python_requires='>=3.7',
     setup_requires=[
         'pytest-runner>=4.2',
     ],


### PR DESCRIPTION
https://github.com/google/proto-task-queue/runs/4875569422?check_suite_focus=true
just failed for a PR that only adds comments, so I'm guessing the issue
is unrelated to the PR. I don't think we're using 3.6 anymore, so I
figured I'd drop support for it rather than figure out what's causing
the failure.