### PR TITLE
Mention Pub/Sub subscription minimum retry delay

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,14 @@ This is not an officially supported Google product.
 In addition to the dependencies listed in `setup.py`, the
 [protobuf compiler and well-known types](https://developers.google.com/protocol-buffers/docs/downloads)
 (Debian: `sudo apt install protobuf-compiler libprotobuf-dev`) are required.
+
+## Pub/Sub Configuration
+
+While this library can be used with the default configuration for topics and
+subscriptions, we recommend setting a 
+[retry policy on the Pub/Sub subscription](https://cloud.google.com/pubsub/docs/handling-failures)
+that Proto Task Queue is reading messages from. Specifically, we recommend setting
+the minimum retry delay to a value greater than 0 so messages aren't immediately
+retried after failing for any reason. You may need to customize your retry delay
+based on your application's particular messages and latency requirements. If you're
+looking for a suggestion, we recommend starting with 60 seconds.


### PR DESCRIPTION
Related to #10, recommend that users of Proto Task Queue configure a minimum retry delay on their subscriptions so `nack`ing messages doesn't create a huge amount of unnecessary load for background workers.