### PR TITLE
Fix integration test with v2 of the pubsub library

### DIFF
--- a/proto_task_queue/integration_test.py
+++ b/proto_task_queue/integration_test.py
@@ -46,16 +46,17 @@ class ProtoTaskQueueTest(absltest.TestCase):
     super().setUp()
 
     self._publisher_client = publisher_client.Client()
-    self._publisher_client.create_topic(_TOPIC_NAME)
+    self._publisher_client.create_topic(name=_TOPIC_NAME)
     self._subscriber_client = subscriber_client.Client()
-    self._subscriber_client.create_subscription(_SUBSCRIPTION_NAME, _TOPIC_NAME)
+    self._subscriber_client.create_subscription(
+        name=_SUBSCRIPTION_NAME, topic=_TOPIC_NAME)
 
     self._requestor = requestor.Requestor()
     self._worker = worker.Worker()
 
   def tearDown(self):
-    self._subscriber_client.delete_subscription(_SUBSCRIPTION_NAME)
-    self._publisher_client.delete_topic(_TOPIC_NAME)
+    self._subscriber_client.delete_subscription(subscription=_SUBSCRIPTION_NAME)
+    self._publisher_client.delete_topic(topic=_TOPIC_NAME)
 
     super().tearDown()
 

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setuptools.setup(
     ],
     install_requires=[
         'attrs>=18.2.0',
-        'google-cloud-pubsub>=0.38.0',
+        'google-cloud-pubsub>=2.0.0',
         'protobuf>=3.6.1',
     ],
     tests_require=[


### PR DESCRIPTION
From a glance at
https://googleapis.dev/python/pubsub/latest/UPGRADING.html I don't see
anything that would need changes in the rest of the code, and the
integration test is the only thing we don't run regularly.